### PR TITLE
request user email permission to ensure email even when not public

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -50,6 +50,9 @@ AUTH_GITHUB_SECRET=${secret}`
           callback_urls: ["http://localhost:3000/api/auth/callback/github"],
           description: "An Auth.js development app, generated via authjs.dev",
           request_oauth_on_install: true,
+          default_permissions: {
+            "emails": "read",
+          }
         } satisfies Manifest)}
       />
       <button className="flex items-center gap-2 p-2 m-2 bg-gray-700 rounded-md border text-white text-xs hover:bg-gray-500 transition-colors focus:bg-black">


### PR DESCRIPTION
Hi! This is a handy little tool. :)

I used it following along with this [platform starter kit](https://vercel.com/guides/nextjs-multi-tenant-application#2.-set-up-environment-variables) setup guide. I ran into an issue, because when you're email is not public on github, the profile returned by github during authentication will have `null` as the email value unless you get explicit permission for the app to read the user's email.
